### PR TITLE
Add OSM - Humanitarian Data Model Layer

### DIFF
--- a/openlayers/html/osm_hdm.html
+++ b/openlayers/html/osm_hdm.html
@@ -1,0 +1,53 @@
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title>OpenLayers OpenStreetMap Layer</title>
+    <link rel="stylesheet" href="qgis.css" type="text/css">
+    <script src="OpenLayers.js"></script>
+    <script src="OlOverviewMarker.js"></script>
+    <script type="text/javascript">
+        var map;
+        var loadEnd;
+        var oloMarker; // OpenLayer Overview Marker
+        function init() {
+            map = new OpenLayers.Map('map', {
+                theme: null,
+                controls: [],
+                projection: new OpenLayers.Projection("EPSG:3857"),
+                units: "m",
+                maxResolution: 156543.0339,
+                maxExtent: new OpenLayers.Bounds(-20037508.34, -20037508.34, 20037508.34, 20037508.34)
+            });
+
+            loadEnd = false;
+            function layerLoadStart(event)
+            {
+              loadEnd = false;
+            }
+            function layerLoadEnd(event)
+            {
+              loadEnd = true;
+            }
+
+            var osm = new OpenLayers.Layer.OSM(
+              "OpenStreetMap - Humanitarian Data Model",
+              ["http://a.tile.openstreetmap.fr/hot/${z}/${x}/${y}.png",
+              "http://b.tile.openstreetmap.fr/hot/${z}/${x}/${y}.png",
+              "http://c.tile.openstreetmap.fr/hot/${z}/${x}/${y}.png"],
+              {
+                eventListeners: {
+                  "loadstart": layerLoadStart,
+                  "loadend": layerLoadEnd
+                }
+              }
+            );
+            map.addLayer(osm);
+            map.addControl(new OpenLayers.Control.Attribution());
+            map.setCenter(new OpenLayers.LonLat(0, 0), 2);
+            oloMarker = new OlOverviewMarker(map, getPathUpper(document.URL) + '/x.png');
+        }
+    </script>
+  </head>
+  <body onload="init()">
+    <div id="map"></div>
+  </body>
+</html>

--- a/openlayers/openlayers_plugin.py
+++ b/openlayers/openlayers_plugin.py
@@ -129,6 +129,7 @@ class OpenlayersPlugin:
     self.olLayerTypeRegistry.add( OlLayerType(self, 'OpenCycleMap', 'osm_icon.png', 'ocm.html', True) )
     self.olLayerTypeRegistry.add( OlLayerType(self, 'OCM Landscape', 'osm_icon.png', 'ocm_landscape.html', True) )
     self.olLayerTypeRegistry.add( OlLayerType(self, 'OCM Public Transport', 'osm_icon.png', 'ocm_transport.html', True) )
+    self.olLayerTypeRegistry.add( OlLayerType(self, 'OSM - Humanitarian Data Model', 'osm_icon.png', 'osm_hdm.html', True) )
     self.olLayerTypeRegistry.add( OlLayerType(self, 'Yahoo Street', 'yahoo_icon.png', 'yahoo_street.html') )
     self.olLayerTypeRegistry.add( OlLayerType(self, 'Yahoo Hybrid', 'yahoo_icon.png', 'yahoo_hybrid.html') )
     self.olLayerTypeRegistry.add( OlLayerType(self, 'Yahoo Satellite', 'yahoo_icon.png',  'yahoo_satellite.html') )


### PR DESCRIPTION
Two PRs so that is available in both versions of QGIS.

It would be great to merger this PR to add this layer by default in the plugin as many humanitarian organization are starting to use this rendering of OSM as a base map.
