### PR TITLE
Fix for issue http://hub.qgis.org/issues/10766

### DIFF
--- a/openlayers/openlayers_plugin.py
+++ b/openlayers/openlayers_plugin.py
@@ -113,9 +113,9 @@ class OpenlayersPlugin:
         self.iface.removePluginWebMenu("_tmp", self._actionAbout)
 
         # Register plugin layer type
-        pluginLayerType = OpenlayersPluginLayerType(self.iface, self.setReferenceLayer,
+        self.pluginLayerType = OpenlayersPluginLayerType(self.iface, self.setReferenceLayer,
                                                     self._olLayerTypeRegistry)
-        QgsPluginLayerRegistry.instance().addPluginLayerType(pluginLayerType)
+        QgsPluginLayerRegistry.instance().addPluginLayerType(self.pluginLayerType)
 
     def unload(self):
         self.iface.webMenu().removeAction(self._olMenu.menuAction())


### PR DESCRIPTION
Tested on QGIS 2.4 on Windows 7 (with QGIS-OSGeo4W-2.4.0-1-Setup-x86_64.exe version). The OpenLayers layer appears in the TOC when reopening a project file.

I still have an issue with the rendering: The layer does not display on the map. To make the layer display on the map, I need to hide and show the layer again (the QDebug error I have for the first load is: "undefined[0]: ReferenceError: Can't find variable: map").
