### PR TITLE
issue google and no zoom-in google_satellite.html

### DIFF
--- a/openlayers/weblayers/html/google_satellite.html
+++ b/openlayers/weblayers/html/google_satellite.html
@@ -1,9 +1,10 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head>
     <title>OpenLayers Google Satellite Layer</title>
+    <meta http-equiv="cache-control" content="no-cache">
     <link rel="stylesheet" href="qgis.css" type="text/css">
     <link rel="stylesheet" href="google.css" type="text/css">
-    <script src="http://maps.google.com/maps/api/js?v=3.3&amp;sensor=false"></script>
+    <script src="http://maps.google.com/maps/api/js?sensor=false"></script>
     <script src="OpenLayers.js"></script>
     <script src="OlOverviewMarker.js"></script>
     <script type="text/javascript">


### PR DESCRIPTION
Hi,

to overcome this issue: http://gis.stackexchange.com/questions/123227/google-maps-openlayer-plugin-not-zooming-in-or-panning and the issue that google layers start drifiting/shifiting away (http://lists.osgeo.org/pipermail/openlayers-users/2010-March/016980.html)

 the v=3.3&amp; is causing a freezing and when zooming it is always back to the full extend. I tested it without v you always can be sure to use the latest version (https://developers.google.com/maps/documentation/javascript/basics).
As I am a GIS web developer in my daily work we have to deal also with the know issue that the google layers start drifting when zooming reach a certain level. To overcome this issue it is only to add that no cache should be stored in the header <meta http-equiv="cache-control" content="no-cache">

All the best,
Richard.