### PR TITLE
Add Stamen Toner lite layer

### DIFF
--- a/openlayers/openlayers_plugin.py
+++ b/openlayers/openlayers_plugin.py
@@ -36,7 +36,7 @@ from weblayers.google_maps import OlGooglePhysicalLayer, OlGoogleStreetsLayer, O
 from weblayers.osm import OlOpenStreetMapLayer, OlOpenCycleMapLayer, OlOCMLandscapeLayer, OlOCMPublicTransportLayer, OlOSMHumanitarianDataModelLayer
 from weblayers.bing_maps import OlBingRoadLayer, OlBingAerialLayer, OlBingAerialLabelledLayer
 from weblayers.apple_maps import OlAppleiPhotoMapLayer
-from weblayers.osm_stamen import OlOSMStamenTonerLayer, OlOSMStamenWatercolorLayer, OlOSMStamenTerrainLayer
+from weblayers.osm_stamen import OlOSMStamenTonerLayer, OlOSMStamenTonerLiteLayer, OlOSMStamenWatercolorLayer, OlOSMStamenTerrainLayer
 from weblayers.map_quest import OlMapQuestOSMLayer, OlMapQuestOpenAerialLayer
 import os.path
 
@@ -95,6 +95,7 @@ class OpenlayersPlugin:
         self._olLayerTypeRegistry.register(OlBingAerialLabelledLayer())
 
         self._olLayerTypeRegistry.register(OlOSMStamenTonerLayer())
+        self._olLayerTypeRegistry.register(OlOSMStamenTonerLiteLayer())
         self._olLayerTypeRegistry.register(OlOSMStamenWatercolorLayer())
         self._olLayerTypeRegistry.register(OlOSMStamenTerrainLayer())
 

--- a/openlayers/weblayers/gdal_tms/stamen_toner_lite.xml
+++ b/openlayers/weblayers/gdal_tms/stamen_toner_lite.xml
@@ -1,0 +1,20 @@
+<GDAL_WMS>
+  <Service name="TMS">
+    <ServerUrl>http://tile.stamen.com/toner-lite/${z}/${x}/${y}.png</ServerUrl>
+  </Service>
+  <DataWindow>
+    <UpperLeftX>-20037508.34</UpperLeftX>
+    <UpperLeftY>20037508.34</UpperLeftY>
+    <LowerRightX>20037508.34</LowerRightX>
+    <LowerRightY>-20037508.34</LowerRightY>
+    <TileLevel>18</TileLevel>
+    <TileCountX>1</TileCountX>
+    <TileCountY>1</TileCountY>
+    <YOrigin>top</YOrigin>
+  </DataWindow>
+  <Projection>EPSG:3857</Projection>
+  <BlockSizeX>256</BlockSizeX>
+  <BlockSizeY>256</BlockSizeY>
+  <BandsCount>3</BandsCount>
+  <Cache />
+</GDAL_WMS>

--- a/openlayers/weblayers/html/stamen_toner_lite.html
+++ b/openlayers/weblayers/html/stamen_toner_lite.html
@@ -1,0 +1,57 @@
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title>OpenLayers Stamen Toner/OSM map Layer</title>
+    <link rel="stylesheet" href="qgis.css" type="text/css">
+    <script src="OpenLayers.js"></script>
+    <script src="OlOverviewMarker.js"></script>
+    <script type="text/javascript">
+        var map;
+        var loadEnd;
+        var oloMarker; // OpenLayer Overview Marker
+        function init() {
+            map = new OpenLayers.Map('map', {
+                theme: null,
+                controls: [],
+                projection: new OpenLayers.Projection("EPSG:900913"),
+                units: "m",
+                maxResolution: 156543.0339,
+                maxExtent: new OpenLayers.Bounds(-20037508.34, -20037508.34, 20037508.34, 20037508.34),
+                adjustZoom: function(zoom) { return zoom; }
+            });
+
+            loadEnd = false;
+            function layerLoadStart(event)
+            {
+              loadEnd = false;
+            }
+            function layerLoadEnd(event)
+            {
+              loadEnd = true;
+            }
+
+            var apple = new OpenLayers.Layer.XYZ(
+              "Stamen Toner/OSM map",
+              "http://tile.stamen.com/toner-lite/${z}/${x}/${y}.png",
+              {
+                sphericalMercator: true,
+                wrapDateLine: true,
+                // TODO: min zoom level 2
+                numZoomLevels: 20,
+//                attribution: "", // FIXME: attribution
+                eventListeners: {
+                  "loadstart": layerLoadStart,
+                  "loadend": layerLoadEnd
+                }
+              }
+            );
+            map.addLayer(apple);
+            map.addControl(new OpenLayers.Control.Attribution());
+            map.setCenter(new OpenLayers.LonLat(0, 0), 3);
+            oloMarker = new OlOverviewMarker(map, getPathUpper(document.URL) + '/x.png');
+        }
+    </script>
+  </head>
+  <body onload="init()">
+    <div id="map"></div>
+  </body>
+</html>

--- a/openlayers/weblayers/osm_stamen.py
+++ b/openlayers/weblayers/osm_stamen.py
@@ -37,6 +37,11 @@ class OlOSMStamenTonerLayer(OlOSMStamenLayer):
     def __init__(self):
         OlOSMStamenLayer.__init__(self, name='Stamen Toner/OSM', html='stamen_toner.html', gdalTMS='stamen_toner.xml')
 
+class OlOSMStamenTonerLiteLayer(OlOSMStamenLayer):
+
+    def __init__(self):
+        OlOSMStamenLayer.__init__(self, name='Stamen Toner Lite/OSM', html='stamen_toner_lite.html', gdalTMS='stamen_toner_lite.xml')
+
 
 class OlOSMStamenWatercolorLayer(OlOSMStamenLayer):
 


### PR DESCRIPTION
[Toner Lite](http://maps.stamen.com/toner-lite/#12/37.7706/-122.3782) uses a light gray color for bodies of water, streets, roads, and highways.

![Toner Lite map tile](https://s3.amazonaws.com/images.m2i.stamen.com/20150731/toner-lite_r4BCbIIVzRk.png)